### PR TITLE
Added support types highlightning

### DIFF
--- a/syntaxes/silq.tmLanguage.json
+++ b/syntaxes/silq.tmLanguage.json
@@ -7,8 +7,24 @@
         "include": "#strings"
     },{
         "include": "#comment"
+    },{
+        "include": "#support"
     }],
     "repository": {
+        "support": {
+            "patterns": [{
+                "match": "\\b(measure|H|phase|rotX|rotY|rotZ|X|Y|Z|dup|array|vector|forget)\\(",
+                "captures": {
+                    "1": {
+                        "name": "support.function.silq"
+                    }
+                }
+            },
+            {
+                "match": "(𝟙|𝔹|ℕ|ℤ|ℚ|ℝ)",
+                "name": "support.type.silq"
+            }]
+        },
         "keywords": {
             "patterns": [{
                 "name": "keyword.control.silq",


### PR DESCRIPTION
I think this improves readability, even though the regular expressions are not foolproof. In the long run, I should probably copy the tmlanguage.json from the d-language, and work from that.

![image](https://user-images.githubusercontent.com/36197/86532314-4b583f80-bec9-11ea-93a5-7ae825325339.png)
